### PR TITLE
feat: add skeleton of bitcoin wallet service

### DIFF
--- a/keychain/keychain.go
+++ b/keychain/keychain.go
@@ -1,0 +1,19 @@
+package keychain
+
+import (
+	"github.com/DE-labtory/zulu/types"
+)
+
+type PubKey interface {
+	Encode() string
+}
+
+type PvtKey interface {
+	Encode() string
+}
+
+func GenerateKey(id string, platform types.Platform) (PubKey, PvtKey) {
+	return nil, nil
+}
+
+func Sign() {}

--- a/types/wallet.go
+++ b/types/wallet.go
@@ -1,0 +1,9 @@
+package types
+
+type Platform string
+
+const (
+	Ethereum Platform = "ethereum"
+	Bitcoin           = "bitcoin"
+	Klaytn            = "klaytn"
+)

--- a/wallet/api.go
+++ b/wallet/api.go
@@ -1,0 +1,1 @@
+package wallet

--- a/wallet/btc/service.go
+++ b/wallet/btc/service.go
@@ -1,0 +1,25 @@
+package btc
+
+import (
+	"github.com/DE-labtory/zulu/keychain"
+	"github.com/DE-labtory/zulu/types"
+)
+
+type Service struct{}
+
+func NewService() *Service {
+	return nil
+}
+
+func (s *Service) CreateNormalWallet(id string) *Wallet {
+	keychain.GenerateKey(id, types.Bitcoin)
+	return nil
+}
+
+func (s *Service) CreateMultiSigWallet(id string) *Wallet {
+	return nil
+}
+
+func (s *Service) Transfer(id string, to string, amount uint) *Transaction {
+	return nil
+}

--- a/wallet/btc/tx.go
+++ b/wallet/btc/tx.go
@@ -1,0 +1,17 @@
+package btc
+
+type Tx struct{}
+
+type TxOutput struct{}
+
+type TxOutputLister interface {
+	ListByAddr(addr string) []TxOutput
+}
+
+type txFactory struct {
+	lister TxOutputLister
+}
+
+func (f *txFactory) create() *Tx {
+	return nil
+}

--- a/wallet/btc/wallet.go
+++ b/wallet/btc/wallet.go
@@ -1,0 +1,11 @@
+package btc
+
+import (
+	"github.com/DE-labtory/zulu/keychain"
+)
+
+type Wallet struct {
+	addr string
+	pub  keychain.PubKey
+	pvt  keychain.PvtKey
+}


### PR DESCRIPTION
# Changelist

## Suggest BTC service module

`keychain` is not my interest. But for prototyping `Wallet` I need to add Key related struct (`PubKey`, `PvtKey`). So I add minimal code to suggest my idea. **"wallet" is dependent on "keychain"**.

### **bitcoin service**
On **service.go** I placed High-Level API of the BTC component as suggest on #19

### **common code to type package**
I've placed  `Platform` type outside of the "wallet" package. At first, I've placed it on `wallet` package. However `wallet/btc` package uses `wallet` package code, so I think it is not good idea. I think `wallet` package code should use `wallet/btc` code, in other words, `wallet` package should dependent on `wallet/btc`.
So I place common code to `types` package which is outside of `wallet` package. `types` package is suggested on #15 by @junbeomlee 

### btc.txFactory, btc.TxOutputLister
`btc.txFactory` will be injected into `btc.Service` and will be used when `Transfer()`. and `btc.txFactory` has `btc.TxOutputLister` which is going to be used when calculate UTXO of wallet.

I think `btc.TxOutputLister` will be implemented by **storage** part


