### PR TITLE
feat/eth-skel

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -1,0 +1,9 @@
+package signer
+
+type Signer struct {
+
+}
+
+func (s *Signer) PubKey() string {
+	return ""
+}

--- a/types/transaction.go
+++ b/types/transaction.go
@@ -1,0 +1,5 @@
+package types
+
+type Transaction struct {
+	TxHash string `json:"txHash"`
+}

--- a/wallet/account.go
+++ b/wallet/account.go
@@ -1,0 +1,10 @@
+package wallet
+
+type Account struct {
+	pub string
+	pvt string
+}
+
+func (a *Account) PubKey() string {
+	return ""
+}

--- a/wallet/eth/service.go
+++ b/wallet/eth/service.go
@@ -1,0 +1,21 @@
+package eth
+
+import (
+	"github.com/DE-labtory/zulu/signer"
+	"github.com/DE-labtory/zulu/types"
+)
+
+type Service struct {}
+
+func NewService() *Service{
+	return nil
+}
+
+func (s *Service) DeriveAccount(signer signer.Signer) types.Account {
+	signer.PubKey()
+	return types.Account{}
+}
+
+func (s *Service) Transfer(signer signer.Signer, to string, amount uint) types.Transaction {
+	return types.Transaction{}
+}

--- a/wallet/service.go
+++ b/wallet/service.go
@@ -1,0 +1,11 @@
+package wallet
+
+import (
+	"github.com/DE-labtory/zulu/signer"
+	"github.com/DE-labtory/zulu/types"
+)
+
+type Service interface {
+	DeriveAccount(signer signer.Signer) types.Account
+	Transfer(signer signer.Signer, to string, amount uint) types.Transaction
+}


### PR DESCRIPTION
# Ethereum wallet service 

## `wallet/account`
This is common struct to get public key. Each wallet service has to get public key for signing using this struct.

## `wallet/service`
This is common interface for each wallet service. `CreateWallet(account Account) types.Address` and `Transfer(account Account, to string, amount uint) types.Transaction` should be implemented by each wallet service. 

## `wallet/eth/service`
This implements `wallet/service` interface.