### PR TITLE
feat: interface and sample for signer, service, resolver

### DIFF
--- a/coin/btc/service.go
+++ b/coin/btc/service.go
@@ -1,0 +1,21 @@
+package btc
+
+import (
+	"github.com/DE-labtory/zulu/signer"
+	"github.com/DE-labtory/zulu/types"
+)
+
+type Service struct {
+}
+
+func NewService() *Service {
+	panic("impl me!")
+}
+
+func (s *Service) Transfer(account types.Account, to types.Address, signer signer.Signer) ([]byte, error) {
+	panic("implement me")
+}
+
+func (s *Service) CreateAccount(signer signer.Signer) (types.Account, error) {
+	panic("implement me")
+}

--- a/coin/eth/service.go
+++ b/coin/eth/service.go
@@ -1,0 +1,21 @@
+package eth
+
+import (
+	"github.com/DE-labtory/zulu/signer"
+	"github.com/DE-labtory/zulu/types"
+)
+
+type Service struct {
+}
+
+func NewService() *Service {
+	panic("impl me!")
+}
+
+func (s *Service) Transfer(account types.Account, to types.Address, signer signer.Signer) ([]byte, error) {
+	panic("implement me")
+}
+
+func (s *Service) CreateAccount(signer signer.Signer) (types.Account, error) {
+	panic("implement me")
+}

--- a/coin/service.go
+++ b/coin/service.go
@@ -1,0 +1,11 @@
+package coin
+
+import (
+	"github.com/DE-labtory/zulu/signer"
+	"github.com/DE-labtory/zulu/types"
+)
+
+type Service interface {
+	Transfer(account types.Account, to types.Address, signer signer.Signer) ([]byte, error)
+	CreateAccount(signer signer.Signer) (types.Account, error)
+}

--- a/resolver.go
+++ b/resolver.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"errors"
+	"github.com/DE-labtory/zulu/coin"
+	"github.com/DE-labtory/zulu/coin/btc"
+	"github.com/DE-labtory/zulu/coin/eth"
+	"github.com/DE-labtory/zulu/signer"
+	"github.com/DE-labtory/zulu/signer/bitcoin"
+	"github.com/DE-labtory/zulu/signer/ethereum"
+	"github.com/DE-labtory/zulu/types"
+)
+
+var (
+	ErrUnknownPlatform = errors.New("unknown platform error")
+	ErrUnknownSymbol   = errors.New("unknown symbol error")
+)
+
+func Resolve(symbol types.Symbol) (coin.Service, signer.Generator, error) {
+	service := getService(symbol)
+	if service == nil {
+		return nil, nil, ErrUnknownSymbol
+	}
+
+	platform := symbol.Platform()
+	generator := getGenerator(platform)
+	if generator == nil {
+		return nil, nil, ErrUnknownPlatform
+	}
+
+	return service, generator, nil
+}
+
+func getService(symbol types.Symbol) coin.Service {
+	switch symbol {
+	case types.BTC:
+		return btc.NewService()
+	case types.ETH:
+		return eth.NewService()
+	case types.USDT:
+		panic("impl me!")
+	case types.KLAY:
+		panic("impl me!")
+	}
+	return nil
+}
+
+func getGenerator(platform types.Platform) signer.Generator {
+	switch platform {
+	case types.Bitcoin:
+		return bitcoin.NewSignerGenerator()
+	case types.Ethereum:
+		return ethereum.NewSignerGenerator()
+	case types.Klaytn:
+		panic("impl me!")
+	}
+	return nil
+}

--- a/signer/bitcoin/generator.go
+++ b/signer/bitcoin/generator.go
@@ -1,0 +1,21 @@
+package bitcoin
+
+import (
+	"github.com/DE-labtory/zulu/signer"
+)
+
+type SignerGenerator struct {
+
+}
+
+func NewSignerGenerator() *SignerGenerator {
+	panic("impl me!")
+}
+
+func (s *SignerGenerator) Gen(payload signer.Payload) signer.Signer {
+	/*
+	ex, generate some signer using string(payload+"BITCOIN") data as seed for signer
+	that means, this gen method is derive signer method from root signer payload
+	 */
+	panic("implement me")
+}

--- a/signer/bitcoin/signer.go
+++ b/signer/bitcoin/signer.go
@@ -1,0 +1,16 @@
+package bitcoin
+
+type Signer struct {
+}
+
+func newSigner(payload interface{}) *Signer {
+	// from bitcoin generator
+	panic("impl me!")
+}
+func (s *Signer) Sign() interface{} {
+	panic("implement me")
+}
+
+func (s *Signer) Public() interface{} {
+	panic("implement me")
+}

--- a/signer/ethereum/generator.go
+++ b/signer/ethereum/generator.go
@@ -1,0 +1,20 @@
+package ethereum
+
+import (
+	"github.com/DE-labtory/zulu/signer"
+)
+
+type SignerGenerator struct {
+}
+
+func NewSignerGenerator() *SignerGenerator {
+	panic("impl me!")
+}
+
+func (s *SignerGenerator) Gen(payload signer.Payload) signer.Signer {
+	/*
+		ex, generate some signer using string(payload+"ETHEREUM") data as seed for signer
+		that means, this gen method is derive signer method from root signer payload
+	*/
+	panic("implement me")
+}

--- a/signer/ethereum/signer.go
+++ b/signer/ethereum/signer.go
@@ -1,0 +1,16 @@
+package ethereum
+
+type Signer struct {
+}
+
+func newSigner(payload interface{}) *Signer {
+	// from ethereum generator
+	panic("impl me!")
+}
+func (s *Signer) Sign() interface{} {
+	panic("implement me")
+}
+
+func (s *Signer) Public() interface{} {
+	panic("implement me")
+}

--- a/signer/generator.go
+++ b/signer/generator.go
@@ -1,0 +1,7 @@
+package signer
+
+type Payload []byte
+
+type Generator interface {
+	Gen(payload Payload) Signer
+}

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -1,0 +1,6 @@
+package signer
+
+type Signer interface {
+	Sign() interface{}   // can be a signature type (e.g. secp256k1, []byte, etc.)
+	Public() interface{} // will return public data (e.g. secp256k1 pub point, []byte, etc.) with hex encoded string
+}

--- a/types/account.go
+++ b/types/account.go
@@ -1,7 +1,9 @@
 package types
 
+type Address string
+
 type Account struct {
-	Address string  `json:"address"`
+	Address Address `json:"address"`
 	Coin    Coin    `json:"coin"`
 	Balance Balance `json:"balance"`
 }

--- a/types/platform.go
+++ b/types/platform.go
@@ -1,9 +1,10 @@
 package types
 
-type Platform string
+type Platform = string
 
 const (
-	Ethereum Platform = "ethereum"
-	Bitcoin           = "bitcoin"
-	Klaytn            = "klaytn"
+	Unknown  = Platform("unknown")
+	Ethereum = Platform("ethereum")
+	Bitcoin  = Platform("bitcoin")
+	Klaytn   = Platform("klaytn")
 )

--- a/types/symbol.go
+++ b/types/symbol.go
@@ -3,7 +3,23 @@ package types
 type Symbol string
 
 const (
-	Btc  Symbol = "btc"
-	Eth         = "eth"
-	Klay        = "klay"
+	BTC  = Symbol("btc")
+	ETH  = Symbol("eth")
+	USDT = Symbol("usdt")
+	KLAY = Symbol("klay")
 )
+
+func (s Symbol) Platform() Platform {
+	switch s {
+	case BTC:
+		return Bitcoin
+	case ETH:
+	case USDT:
+		return Ethereum
+	case KLAY:
+		return Klaytn
+	default:
+		break
+	}
+	return Unknown
+}

--- a/wallet.go
+++ b/wallet.go
@@ -1,0 +1,41 @@
+package main
+
+import "github.com/DE-labtory/zulu/db/leveldb"
+
+type WalletId string
+
+type Wallet struct {
+	Id            WalletId
+	signerPayload []byte
+}
+
+func NewWallet(password string, payload interface{}) *Wallet {
+	// using password, payload ( random io or some byte seed or etc. )
+	// encrypt payload using password and return new wallet objects ( using AES, etc. )
+	panic("impl me!")
+}
+func (w *Wallet) GetSignerPayload(password string) ([]byte, error) {
+	panic("impl me!")
+}
+
+type WalletStore interface {
+	Get(id WalletId) *Wallet
+	Set(wallet Wallet) error
+}
+
+// todo split below impl code to other file
+type LevelDBWalletStore struct {
+	db leveldb.DBProvider
+}
+
+func (l *LevelDBWalletStore) Get(id WalletId) *Wallet {
+	panic("implement me")
+}
+
+func (l *LevelDBWalletStore) Set(wallet Wallet) error {
+	panic("implement me")
+}
+
+func NewLevelDBWalletStore(path string) (*LevelDBWalletStore, error) {
+	panic("impl me!")
+}


### PR DESCRIPTION
skel code

service 는 symbol별로 생기고,
signer 는 platform별로 생겨서 resolve 로 받는게 각각다릅니다.

1. service, signer패키지에 각각 resolver.go 를 만들어서 어댑터같은곳에서 ServiceResolver, SignerResolver를 두번써서 각각에 symbol, platform정보 넘겨주기

2. platform정보는 symbol로부터 추출가능하니 하나의 function에 symbol정보를 넣어 service,signer둘다 받기

일단 2번으로 main package 에 resolver.go를 해두었는데 좋은 의견잇으면 주세요~