### PR TITLE
fix: add a missing return type to follow `store` interface

### DIFF
--- a/keychain/mem/store.go
+++ b/keychain/mem/store.go
@@ -33,11 +33,11 @@ func (ks *KeyStore) Get(id string) (keychain.Key, error) {
 	return k, nil
 }
 
-func (ks *KeyStore) GetAll() []keychain.Key {
+func (ks *KeyStore) GetAll() ([]keychain.Key, error) {
 	var keys []keychain.Key
 
 	for _, v := range ks.keys {
 		keys = append(keys, v)
 	}
-	return keys
+	return keys, nil
 }

--- a/keychain/mem/store_test.go
+++ b/keychain/mem/store_test.go
@@ -237,15 +237,17 @@ func TestGetAll(t *testing.T) {
 	var expected []keychain.Key
 
 	// case: empty key store
-	keys := ks.GetAll()
+	keys, err := ks.GetAll()
+	assert.NoError(t, err)
 	assert.ElementsMatch(t, keys, expected)
 
 	// case: key store has 1 key-value pair
-	err := ks.Store(tests[0].key)
+	err = ks.Store(tests[0].key)
 	expected = append(expected, tests[0].key)
 	assert.NoError(t, err)
 
-	keys = ks.GetAll()
+	keys, err = ks.GetAll()
+	assert.NoError(t, err)
 	assert.ElementsMatch(t, keys, expected)
 
 	// case: key store has 2 key-value pair
@@ -253,6 +255,7 @@ func TestGetAll(t *testing.T) {
 	expected = append(expected, tests[1].key)
 	assert.NoError(t, err)
 
-	keys = ks.GetAll()
+	keys, err = ks.GetAll()
+	assert.NoError(t, err)
 	assert.ElementsMatch(t, keys, expected)
 }


### PR DESCRIPTION
the `Store` interface:
```
type Store interface {
	Store(k Key) error
	Get(id string) (Key, error)
	GetAll() ([]Key, error)
}
```